### PR TITLE
Fix wiki links for GitHub Pages

### DIFF
--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -3,6 +3,12 @@ import Layout from '../../layouts/Layout.astro';
 import ContentCard from '../../components/ContentCard.astro';
 import FilterBox from '../../components/FilterBox.astro';
 import { getCollection } from 'astro:content';
+import {
+  getBlogUrl,
+  getWikiUrl,
+  getBlogIndexUrl,
+  getWikiIndexUrl,
+} from '../../utils/url';
 
 export async function getStaticPaths() {
   const allBlogPosts = await getCollection('blog', ({ data }) => !data.draft);
@@ -109,7 +115,7 @@ const wikiCount = sortedWikiEntries.length;
             <ContentCard
               title={post.data.title}
               description={post.data.description}
-              url={`/blog/${post.slug}`}
+              url={getBlogUrl(post.slug)}
               tags={post.data.tags}
               category={post.data.category}
               date={post.data.date}
@@ -130,7 +136,7 @@ const wikiCount = sortedWikiEntries.length;
             <ContentCard
               title={entry.data.title}
               description={entry.data.description}
-              url={`/wiki/${entry.slug}`}
+              url={getWikiUrl(entry.slug)}
               tags={entry.data.tags}
               category={entry.data.category}
               isWiki={true}
@@ -149,10 +155,16 @@ const wikiCount = sortedWikiEntries.length;
           Try browsing all content instead.
         </p>
         <div class="mt-4 flex justify-center gap-4">
-          <a href="/blog" class="text-accent-600 dark:text-accent-400 hover:underline">
+          <a
+            href={getBlogIndexUrl()}
+            class="text-accent-600 dark:text-accent-400 hover:underline"
+          >
             View all blog posts
           </a>
-          <a href="/wiki" class="text-accent-600 dark:text-accent-400 hover:underline">
+          <a
+            href={getWikiIndexUrl()}
+            class="text-accent-600 dark:text-accent-400 hover:underline"
+          >
             View all wiki articles
           </a>
         </div>

--- a/src/pages/wiki/index.astro
+++ b/src/pages/wiki/index.astro
@@ -2,6 +2,7 @@
 import { getCollection } from "astro:content";
 import type { CollectionEntry } from "astro:content";
 import Layout from "../../layouts/Layout.astro";
+import { getWikiUrl } from "../../utils/url";
 
 // Get all wiki entries
 const wikiEntries = await getCollection(
@@ -50,7 +51,7 @@ Object.keys(categories).forEach((category) => {
                 .replace(/\/+/g, "/");
               return (
                 <a
-                  href={`/wiki/${cleanSlug}`}
+                  href={getWikiUrl(cleanSlug)}
                   class="block p-6 bg-white dark:bg-primary-900 rounded-lg shadow-md hover:shadow-lg transition-shadow"
                 >
                   <h3 class="text-xl font-semibold mb-2">{entry.data.title}</h3>


### PR DESCRIPTION
## Summary
- include routing helpers on tag page
- fix wiki card URLs on tag and wiki index pages
- update fallback links for blog/wiki indexes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: network restrictions)*