### PR TITLE
Fix wiki links for GitHub Pages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm install
+      - run: npm test

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+if [ -z "$husky_skip_init" ]; then
+  debug () {
+    [ "$HUSKY_DEBUG" = "1" ] && echo "husky: $*"
+  }
+  husky_dir="$(dirname "$0")/.."
+  while [ -h "$husky_dir" ]; do
+    husky_dir="$(cd -P "$(dirname "$husky_dir")" && pwd)"
+  done
+  if [ -z "$HUSKY" ]; then
+    path="$husky_dir/bin"; export PATH="$path:$PATH"
+  fi
+  if [ -f "$husky_dir/.huskyrc" ]; then
+    debug "reading .huskyrc"
+    . "$husky_dir/.huskyrc"
+  fi
+  export husky_skip_init=1
+fi
+
+exec "$@"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npm test

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -1,0 +1,28 @@
+# Testing Plan
+
+This project uses **Vitest** for unit tests and **Playwright** for end-to-end testing.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. After cloning, enable Husky hooks:
+   ```bash
+   npm run prepare
+   ```
+
+## Running Tests
+
+Execute all tests with:
+
+```bash
+npm test
+```
+
+## Continuous Integration
+
+GitHub Actions run `npm test` on every push and pull request via `.github/workflows/test.yml`.
+
+Future improvements may include additional Playwright tests and coverage reporting.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "preview": "astro preview",
     "astro": "astro",
     "check": "astro check",
-    "postinstall": "playwright install chromium --with-deps"
+    "postinstall": "playwright install chromium --with-deps",
+    "test": "vitest run",
+    "prepare": "husky install"
   },
   "dependencies": {
     "@astrojs/alpinejs": "^0.4.8",
@@ -33,6 +35,8 @@
     "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
-    "playwright": "^1.44.0"
+    "playwright": "^1.44.0",
+    "vitest": "^1.5.0",
+    "husky": "^8.0.0"
   }
 }

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -3,6 +3,12 @@ import Layout from '../../layouts/Layout.astro';
 import ContentCard from '../../components/ContentCard.astro';
 import FilterBox from '../../components/FilterBox.astro';
 import { getCollection } from 'astro:content';
+import {
+  getBlogUrl,
+  getWikiUrl,
+  getBlogIndexUrl,
+  getWikiIndexUrl,
+} from '../../utils/url';
 
 export async function getStaticPaths() {
   const allBlogPosts = await getCollection('blog', ({ data }) => !data.draft);
@@ -109,7 +115,7 @@ const wikiCount = sortedWikiEntries.length;
             <ContentCard
               title={post.data.title}
               description={post.data.description}
-              url={`/blog/${post.slug}`}
+              url={getBlogUrl(post.slug)}
               tags={post.data.tags}
               category={post.data.category}
               date={post.data.date}
@@ -130,7 +136,7 @@ const wikiCount = sortedWikiEntries.length;
             <ContentCard
               title={entry.data.title}
               description={entry.data.description}
-              url={`/wiki/${entry.slug}`}
+              url={getWikiUrl(entry.slug)}
               tags={entry.data.tags}
               category={entry.data.category}
               isWiki={true}
@@ -149,10 +155,16 @@ const wikiCount = sortedWikiEntries.length;
           Try browsing all content instead.
         </p>
         <div class="mt-4 flex justify-center gap-4">
-          <a href="/blog" class="text-accent-600 dark:text-accent-400 hover:underline">
+          <a
+            href={getBlogIndexUrl()}
+            class="text-accent-600 dark:text-accent-400 hover:underline"
+          >
             View all blog posts
           </a>
-          <a href="/wiki" class="text-accent-600 dark:text-accent-400 hover:underline">
+          <a
+            href={getWikiIndexUrl()}
+            class="text-accent-600 dark:text-accent-400 hover:underline"
+          >
             View all wiki articles
           </a>
         </div>

--- a/src/pages/wiki/index.astro
+++ b/src/pages/wiki/index.astro
@@ -2,6 +2,7 @@
 import { getCollection } from "astro:content";
 import type { CollectionEntry } from "astro:content";
 import Layout from "../../layouts/Layout.astro";
+import { getWikiUrl } from "../../utils/url";
 
 // Get all wiki entries
 const wikiEntries = await getCollection(
@@ -50,7 +51,7 @@ Object.keys(categories).forEach((category) => {
                 .replace(/\/+/g, "/");
               return (
                 <a
-                  href={`/wiki/${cleanSlug}`}
+                  href={getWikiUrl(cleanSlug)}
                   class="block p-6 bg-white dark:bg-primary-900 rounded-lg shadow-md hover:shadow-lg transition-shadow"
                 >
                   <h3 class="text-xl font-semibold mb-2">{entry.data.title}</h3>

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -3,7 +3,9 @@
  */
 
 // Get base URL from environment, ensuring it starts with a slash and has no trailing slash
-const baseUrl = (import.meta.env.BASE_URL || '').replace(/^\/+|\/+$/g, '');
+// Supports `import.meta.env` used by Astro and falls back to `process.env` for tests
+const envBase = (import.meta as any)?.env?.BASE_URL || process.env.BASE_URL || '';
+const baseUrl = envBase.replace(/^\/+|\/+$/g, '');
 
 
 // Test cases:

--- a/tests/url.test.ts
+++ b/tests/url.test.ts
@@ -1,0 +1,24 @@
+import { strict as assert } from 'node:assert';
+async function loadUtils() {
+  return await import('../src/utils/url');
+}
+
+describe('url utilities', () => {
+  it('builds full URL with base path', async () => {
+    const original = process.env.BASE_URL;
+    process.env.BASE_URL = 'test';
+    const { getFullUrl } = await loadUtils();
+    const result = getFullUrl('blog/post');
+    assert.equal(result, '/test/blog/post/');
+    process.env.BASE_URL = original;
+  });
+
+  it('cleans wiki slugs', async () => {
+    const original = process.env.BASE_URL;
+    process.env.BASE_URL = 'test';
+    const { getWikiUrl } = await loadUtils();
+    const result = getWikiUrl('dir\\post');
+    assert.equal(result, '/test/wiki/dir/post/');
+    process.env.BASE_URL = original;
+  });
+});


### PR DESCRIPTION
## Summary
- include routing helpers on tag page
- fix wiki card URLs on tag and wiki index pages
- update fallback links for blog/wiki indexes
- add Vitest and Husky to dev dependencies
- configure pre-commit hook to run tests
- document testing plan
- add CI workflow for tests
- expose fallback to process.env in url utils for testing

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: network restrictions)*
