### PR TITLE
Add subcategory wiki indexes

### DIFF
--- a/src/content/wiki/operating-model/alignment/_index.md
+++ b/src/content/wiki/operating-model/alignment/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Alignment"
+description: "Practices for aligning strategy and execution"
+category: "Organisation Design"
+subcategory: "Alignment"
+tags: ["operating-model", "alignment"]
+isIndex: true
+order: 0
+---
+
+# Alignment Overview
+
+This section introduces key practices for keeping teams and objectives in sync.

--- a/src/content/wiki/operating-model/alignment/alignment-feedback.md
+++ b/src/content/wiki/operating-model/alignment/alignment-feedback.md
@@ -8,6 +8,7 @@ tags:
   - metrics
   - continuous-improvement
 category: "Organisation Design"
+subcategory: "Alignment"
 date: 2025-04-30
 ---
 

--- a/src/content/wiki/operating-model/alignment/mission-objectives.md
+++ b/src/content/wiki/operating-model/alignment/mission-objectives.md
@@ -9,6 +9,7 @@ tags:
   - objectives
   - strategy
 category: "Organisation Design"
+subcategory: "Alignment"
 date: 2025-04-30
 ---
 

--- a/src/content/wiki/operating-model/alignment/mission-product-canvas.md
+++ b/src/content/wiki/operating-model/alignment/mission-product-canvas.md
@@ -8,6 +8,7 @@ tags:
   - strategy
   - canvas
 category: "Organisation Design"
+subcategory: "Alignment"
 date: 2025-04-30
 ---
 

--- a/src/content/wiki/operating-model/alignment/objectives-wardley.md
+++ b/src/content/wiki/operating-model/alignment/objectives-wardley.md
@@ -8,6 +8,7 @@ tags:
   - wardley
   - mapping
 category: "Organisation Design"
+subcategory: "Alignment"
 date: 2025-04-30
 ---
 

--- a/src/content/wiki/operating-model/alignment/why-purpose.md
+++ b/src/content/wiki/operating-model/alignment/why-purpose.md
@@ -8,6 +8,7 @@ tags:
   - purpose
   - vision
 category: "Organisation Design"
+subcategory: "Alignment"
 date: 2025-04-30
 ---
 

--- a/src/content/wiki/operating-model/optimization/_index.md
+++ b/src/content/wiki/operating-model/optimization/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Optimization"
+description: "Guidance on optimizing flow, cost and motivation"
+category: "Organisation Design"
+subcategory: "Optimization"
+tags: ["operating-model", "optimization"]
+isIndex: true
+order: 0
+---
+
+# Optimization Overview
+
+Explore ways to streamline processes and improve developer happiness.

--- a/src/content/wiki/operating-model/optimization/optimise-cost.md
+++ b/src/content/wiki/operating-model/optimization/optimise-cost.md
@@ -8,6 +8,7 @@ tags:
   - efficiency
   - finops
 category: "Organisation Design"
+subcategory: "Optimization"
 date: 2025-04-30
 ---
 

--- a/src/content/wiki/operating-model/optimization/optimise-flow.md
+++ b/src/content/wiki/operating-model/optimization/optimise-flow.md
@@ -8,6 +8,7 @@ tags:
   - flow
   - metrics
 category: "Organisation Design"
+subcategory: "Optimization"
 date: 2025-04-30
 ---
 

--- a/src/content/wiki/operating-model/optimization/optimise-motivation.md
+++ b/src/content/wiki/operating-model/optimization/optimise-motivation.md
@@ -8,6 +8,7 @@ tags:
   - culture
   - engagement
 category: "Organisation Design"
+subcategory: "Optimization"
 date: 2025-04-30
 ---
 

--- a/src/content/wiki/organization/team-structure/_index.md
+++ b/src/content/wiki/organization/team-structure/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Team Structure"
+description: "Patterns for structuring teams to support architecture"
+category: "Organisation Design"
+subcategory: "Team Structure"
+tags: ["organization", "team-structure"]
+isIndex: true
+order: 0
+---
+
+# Team Structure Overview
+
+Learn how team setup influences system design and autonomy.

--- a/src/content/wiki/organization/team-structure/conways-law.md
+++ b/src/content/wiki/organization/team-structure/conways-law.md
@@ -8,6 +8,7 @@ tags:
   - inverse_conway
   - system_design
 category: "Organisation Design"
+subcategory: "Team Structure"
 date: 2025-04-30
 ---
 

--- a/src/content/wiki/organization/team-structure/decoupling_teams.md
+++ b/src/content/wiki/organization/team-structure/decoupling_teams.md
@@ -1,7 +1,6 @@
 ---
 title: Decoupling Teams & Inverse Organisation
 description: A pragmatic rationale for engineering leaders explaining why decoupling teams, removing dependencies, and designing inverse organisations boosts flow, quality, and autonomy.
-date: 2025-04-30
 tags:
   - team_topologies
   - inverse_conway
@@ -9,6 +8,8 @@ tags:
   - decoupling
   - dependencies
 category: "Organisation Design"
+subcategory: "Team Structure"
+date: 2025-04-30
 ---
 
 ### Decoupling Teams & Inverse Organisation  

--- a/src/content/wiki/organization/team-structure/team-topologies.md
+++ b/src/content/wiki/organization/team-structure/team-topologies.md
@@ -8,6 +8,7 @@ tags:
   - organization
   - structure
 category: "Organisation Design"
+subcategory: "Team Structure"
 date: 2025-04-30
 ---
 

--- a/src/pages/wiki/index.astro
+++ b/src/pages/wiki/index.astro
@@ -12,27 +12,64 @@ const wikiEntries = await getCollection(
   },
 );
 
-// Group entries by category
-const categories = wikiEntries.reduce(
+// Organize entries by category and optional subcategory
+interface WikiEntry extends CollectionEntry<"wiki"> {}
+interface CategoryStructure {
+  index?: WikiEntry;
+  entries: WikiEntry[];
+  subcategories: Record<string, {
+    index?: WikiEntry;
+    entries: WikiEntry[];
+  }>;
+}
+
+const categories = wikiEntries.reduce<Record<string, CategoryStructure>>(
   (acc, entry) => {
     const category = entry.data.category;
+    const subcategory = entry.data.subcategory;
+
     if (!acc[category]) {
-      acc[category] = [];
+      acc[category] = { entries: [], subcategories: {} };
     }
-    acc[category].push(entry);
+
+    if (entry.data.isIndex) {
+      if (subcategory) {
+        if (!acc[category].subcategories[subcategory]) {
+          acc[category].subcategories[subcategory] = { entries: [] };
+        }
+        acc[category].subcategories[subcategory].index = entry;
+      } else {
+        acc[category].index = entry;
+      }
+    } else if (subcategory) {
+      if (!acc[category].subcategories[subcategory]) {
+        acc[category].subcategories[subcategory] = { entries: [] };
+      }
+      acc[category].subcategories[subcategory].entries.push(entry);
+    } else {
+      acc[category].entries.push(entry);
+    }
+
     return acc;
   },
-  {} as Record<string, CollectionEntry<"wiki">[]>,
+  {},
 );
 
-// Sort entries within each category
-Object.keys(categories).forEach((category) => {
-  categories[category].sort((a, b) => {
-    const orderA = a.data.order || 0;
-    const orderB = b.data.order || 0;
-    return orderA - orderB;
-  });
-});
+const sortEntries = (a: WikiEntry, b: WikiEntry) => {
+  if ((a.data.order ?? 999) !== (b.data.order ?? 999)) {
+    return (a.data.order ?? 999) - (b.data.order ?? 999);
+  }
+  return a.data.title.localeCompare(b.data.title);
+};
+
+for (const category in categories) {
+  categories[category].entries.sort(sortEntries);
+  for (const sub in categories[category].subcategories) {
+    categories[category].subcategories[sub].entries.sort(sortEntries);
+  }
+}
+
+const sortedCategories = Object.keys(categories).sort();
 ---
 
 <Layout title="Technical Leadership Wiki">
@@ -40,37 +77,86 @@ Object.keys(categories).forEach((category) => {
     <h1 class="text-4xl font-bold mb-8">Technical Leadership Wiki</h1>
 
     {
-      Object.entries(categories).map(([category, entries]) => (
-        <div class="mb-12">
-          <h2 class="text-2xl font-semibold mb-4">{category}</h2>
-          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {entries.map((entry) => {
-              // Get the clean slug path
-              const cleanSlug = entry.slug
-                .replace(/\\/g, "/")
-                .replace(/\/+/g, "/");
-              return (
+      sortedCategories.map((category) => {
+        const content = categories[category];
+        return (
+          <div class="mb-12">
+            <h2 class="text-2xl font-semibold mb-4">{category}</h2>
+
+            {content.index && (
+              <div class="mb-6">
                 <a
-                  href={getWikiUrl(cleanSlug)}
+                  href={getWikiUrl(content.index.slug)}
                   class="block p-6 bg-white dark:bg-primary-900 rounded-lg shadow-md hover:shadow-lg transition-shadow"
                 >
-                  <h3 class="text-xl font-semibold mb-2">{entry.data.title}</h3>
+                  <h3 class="text-xl font-semibold mb-2">{content.index.data.title}</h3>
                   <p class="text-gray-600 dark:text-gray-300 mb-4">
-                    {entry.data.description}
+                    {content.index.data.description}
                   </p>
-                  <div class="flex flex-wrap gap-2">
-                    {entry.data.tags.map((tag) => (
-                      <span class="px-2 py-1 bg-primary-100 dark:bg-primary-800 text-primary-800 dark:text-primary-100 text-sm rounded">
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
                 </a>
-              );
-            })}
+              </div>
+            )}
+
+            {content.entries.length > 0 && (
+              <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                {content.entries.map((entry) => {
+                  const cleanSlug = entry.slug.replace(/\\/g, '/').replace(/\/+/g, '/');
+                  return (
+                    <a
+                      href={getWikiUrl(cleanSlug)}
+                      class="block p-6 bg-white dark:bg-primary-900 rounded-lg shadow-md hover:shadow-lg transition-shadow"
+                    >
+                      <h3 class="text-xl font-semibold mb-2">{entry.data.title}</h3>
+                      <p class="text-gray-600 dark:text-gray-300 mb-4">
+                        {entry.data.description}
+                      </p>
+                    </a>
+                  );
+                })}
+              </div>
+            )}
+
+            {Object.entries(content.subcategories).map(([sub, subContent]) => (
+              <div class="mt-8">
+                <h3 class="text-xl font-semibold mb-3">{sub}</h3>
+
+                {subContent.index && (
+                  <div class="mb-4">
+                    <a
+                      href={getWikiUrl(subContent.index.slug)}
+                      class="block p-6 bg-white dark:bg-primary-900 rounded-lg shadow-md hover:shadow-lg transition-shadow"
+                    >
+                      <h4 class="text-lg font-semibold mb-2">{subContent.index.data.title}</h4>
+                      <p class="text-gray-600 dark:text-gray-300 mb-4">
+                        {subContent.index.data.description}
+                      </p>
+                    </a>
+                  </div>
+                )}
+
+                {subContent.entries.length > 0 && (
+                  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {subContent.entries.map((entry) => {
+                      const cleanSlug = entry.slug.replace(/\\/g, '/').replace(/\/+/g, '/');
+                      return (
+                        <a
+                          href={getWikiUrl(cleanSlug)}
+                          class="block p-6 bg-white dark:bg-primary-900 rounded-lg shadow-md hover:shadow-lg transition-shadow"
+                        >
+                          <h4 class="text-lg font-semibold mb-2">{entry.data.title}</h4>
+                          <p class="text-gray-600 dark:text-gray-300 mb-4">
+                            {entry.data.description}
+                          </p>
+                        </a>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            ))}
           </div>
-        </div>
-      ))
+        );
+      })
     }
   </div>
 </Layout>


### PR DESCRIPTION
## Summary
- add subcategory frontmatter to wiki articles
- create `_index.md` pages for Alignment, Optimization and Team Structure
- display categories and subcategories on wiki index page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684caa52d450832494861ac895fadd08