### PR TITLE
Add research links to tools page

### DIFF
--- a/src/pages/tools.astro
+++ b/src/pages/tools.astro
@@ -34,8 +34,8 @@ import InteractiveCalculators from '../components/InteractiveCalculators.astro';
               DORA Metrics Calculator
             </h3>
             <p class="text-primary-600 dark:text-primary-300 text-sm mb-4">
-              Based on Google's DevOps Research and Assessment (DORA) program research from the 
-              State of DevOps reports (2019-2023) analyzing thousands of organizations worldwide.
+              Based on <a href="https://dora.dev" target="_blank" rel="noopener noreferrer">Google's DevOps Research and Assessment (DORA) program</a> research from the
+              <a href="https://dora.dev/research" target="_blank" rel="noopener noreferrer">State of DevOps reports (2019-2023)</a> analyzing thousands of organizations worldwide.
             </p>
             <div class="text-xs text-primary-500 dark:text-primary-400 space-y-2">
               <div>
@@ -54,7 +54,7 @@ import InteractiveCalculators from '../components/InteractiveCalculators.astro';
               Technical Debt Calculator
             </h3>
             <p class="text-primary-600 dark:text-primary-300 text-sm mb-4">
-              Estimates the hidden costs of technical debt based on industry research showing 
+              Estimates the hidden costs of technical debt based on <a href="https://stripe.com/reports/developer-coefficient-2018" target="_blank" rel="noopener noreferrer">industry research</a> showing
               teams typically spend 20-40% of their time dealing with technical debt.
             </p>
           </div>
@@ -63,8 +63,8 @@ import InteractiveCalculators from '../components/InteractiveCalculators.astro';
               Incident Cost Calculator
             </h3>
             <p class="text-primary-600 dark:text-primary-300 text-sm mb-4">
-              Calculates the true cost of system outages including direct revenue loss, 
-              team response costs, and customer impact multipliers.
+              Calculates the true cost of system outages including direct revenue loss,
+              team response costs, and customer impact multipliers, guided by <a href="https://www.gartner.com/en/newsroom/press-releases/2014-07-31-gartner-says-downtime-costs" target="_blank" rel="noopener noreferrer">industry research on downtime costs</a>.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- link DORA program and State of DevOps reports to official site
- cite industry research on technical debt and downtime costs

## Testing
- `npm test -- --run`
- `npm run check` *(fails: page.addScriptTag: Target page, context or browser has been closed)*

------
https://chatgpt.com/codex/tasks/task_b_689c518342408324be1df2d77d215a00