### PR TITLE
fix: fetch assessment json from GitHub Pages path

### DIFF
--- a/src/components/AssessmentCards.astro
+++ b/src/components/AssessmentCards.astro
@@ -117,7 +117,7 @@
       async loadAssessments() {
         try {
           this.isLoading = true;
-          const response = await fetch('/tech-leadership/assessments/index.json/');
+          const response = await fetch('/tech-leadership/assessments/index.json');
           const allAssessments = await response.json();
           
           // Split assessments by type

--- a/src/pages/assessments/[id].astro
+++ b/src/pages/assessments/[id].astro
@@ -609,7 +609,7 @@ const assessmentTitle = id === 'engineering-practices'
           try {
             this.isLoading = true;
             const assessmentId = window.location.pathname.split('/').filter(p => p).pop();
-            const response = await fetch(`/tech-leadership/assessments/${assessmentId}.json/`);
+            const response = await fetch(`/tech-leadership/assessments/${assessmentId}.json`);
             
             if (!response.ok) {
               throw new Error(`HTTP error! status: ${response.status}`);
@@ -922,7 +922,7 @@ const assessmentTitle = id === 'engineering-practices'
           try {
             this.isLoading = true;
             const assessmentId = window.location.pathname.split('/').filter(p => p).pop();
-            const response = await fetch(`/tech-leadership/assessments/${assessmentId}.json/`);
+            const response = await fetch(`/tech-leadership/assessments/${assessmentId}.json`);
             
             if (!response.ok) {
               throw new Error(`HTTP error! status: ${response.status}`);


### PR DESCRIPTION
## Summary
- fix AssessmentCards fetch to use GitHub Pages paths
- fix assessment page fetch to GitHub Pages paths

## Testing
- `npm test`
- `curl http://localhost:8000/tech-leadership/assessments/index.json`
- `curl http://localhost:8000/tech-leadership/assessments/cloud-native-maturity.json`


------
https://chatgpt.com/codex/tasks/task_b_689c597a67c08324af65518bd61b8bf3