### PR TITLE
feat: enrich assessment next steps

### DIFF
--- a/docs/RFC-004-static-site-enhancements.md
+++ b/docs/RFC-004-static-site-enhancements.md
@@ -111,7 +111,13 @@ interface StaticAssessment {
         scoreRange: [0, 2];
         title: 'Focus on Foundation';
         items: ['Implement basic version control', 'Establish development guidelines'];
-        nextSteps: ['/wiki/engineering-practices/normalization/'];
+        nextSteps: [
+          {
+            href: '/wiki/engineering-practices/normalization/',
+            title: 'Normalization Stage',
+            description: 'Foundation building blocks: version control, guidelines, and standardized systems'
+          }
+        ];
       }
     ];
   };

--- a/public/tech-leadership/assessments/cloud-native-maturity.json
+++ b/public/tech-leadership/assessments/cloud-native-maturity.json
@@ -6,39 +6,36 @@
   "version": "1.0",
   "category": "Cloud Native",
   "estimatedTime": 10,
-  "tags": ["cloud-native", "maturity-assessment", "organizational-transformation", "devops"],
-  "createdAt": "2025-07-14T00:00:00.000Z",
-  "updatedAt": "2025-07-14T00:00:00.000Z",
   "dimensions": [
     {
       "id": "culture",
       "title": "Culture",
       "description": "Organizational mindset and approach to change, learning, and collaboration",
-      "weight": 1.0
+      "weight": 1
     },
     {
       "id": "product-management",
       "title": "Product Management",
       "description": "How products are planned, developed, and managed throughout their lifecycle",
-      "weight": 1.0
+      "weight": 1
     },
     {
       "id": "delivery",
       "title": "Delivery",
       "description": "Methods and practices for delivering software to production",
-      "weight": 1.0
+      "weight": 1
     },
     {
       "id": "architecture",
       "title": "Architecture",
       "description": "System design patterns and architectural approaches",
-      "weight": 1.0
+      "weight": 1
     },
     {
       "id": "infrastructure",
       "title": "Infrastructure",
       "description": "Infrastructure patterns and management approaches",
-      "weight": 1.0
+      "weight": 1
     }
   ],
   "maturityLevels": [
@@ -117,64 +114,127 @@
   },
   "sections": [],
   "scoring": {
-    "interpretation": "The Cloud Native Maturity Matrix helps you visualize your organization's current state across multiple dimensions of cloud native transformation. Each dimension represents a critical aspect of modern software delivery and operations.",
+    "maxScore": 25,
+    "weights": {
+      "cloud-native-dimensions": 1
+    },
     "recommendations": [
       {
+        "scoreRange": [
+          0,
+          10
+        ],
         "title": "Foundation Building",
         "description": "Focus on establishing basic processes and moving away from ad-hoc approaches.",
-        "applicableWhen": {
-          "averageLevel": 2
-        },
-        "actions": [
+        "items": [
           "Implement version control for all code and infrastructure",
           "Establish basic CI/CD pipelines",
           "Create cross-functional teams",
           "Adopt agile development practices"
         ],
+        "nextSteps": [
+          {
+            "href": "/tech-leadership/wiki/cloud-native/foundation/",
+            "title": "Cloud Native Foundation",
+            "description": "Wiki article with detailed guidance"
+          },
+          {
+            "href": "/tech-leadership/blog/cloud-native-getting-started/",
+            "title": "Cloud Native Getting Started",
+            "description": "Blog post with practical insights"
+          }
+        ],
         "priority": "high"
       },
       {
-        "title": "Agile Transformation", 
+        "scoreRange": [
+          11,
+          15
+        ],
+        "title": "Agile Transformation",
         "description": "Mature your agile practices and begin cloud adoption.",
-        "applicableWhen": {
-          "averageLevel": 3
-        },
-        "actions": [
+        "items": [
           "Implement comprehensive testing strategies",
           "Adopt infrastructure as code",
           "Establish monitoring and observability",
           "Begin containerization journey"
         ],
+        "nextSteps": [
+          {
+            "href": "/tech-leadership/wiki/cloud-native/agile-transformation/",
+            "title": "Agile Transformation",
+            "description": "Wiki article with detailed guidance"
+          },
+          {
+            "href": "/tech-leadership/tools/",
+            "title": "Tools",
+            "description": "Interactive tool or calculator"
+          }
+        ],
         "priority": "high"
       },
       {
+        "scoreRange": [
+          16,
+          20
+        ],
         "title": "Cloud Native Adoption",
         "description": "Embrace cloud native patterns and microservices architecture.",
-        "applicableWhen": {
-          "averageLevel": 4
-        },
-        "actions": [
+        "items": [
           "Implement microservices architecture",
           "Adopt Kubernetes and container orchestration",
           "Implement comprehensive observability",
           "Establish chaos engineering practices"
         ],
+        "nextSteps": [
+          {
+            "href": "/tech-leadership/wiki/cloud-native/microservices/",
+            "title": "Microservices",
+            "description": "Wiki article with detailed guidance"
+          },
+          {
+            "href": "/tech-leadership/wiki/cloud-native/observability/",
+            "title": "Observability",
+            "description": "Wiki article with detailed guidance"
+          }
+        ],
         "priority": "medium"
       },
       {
+        "scoreRange": [
+          21,
+          25
+        ],
         "title": "Future-Ready Organization",
         "description": "Leverage AI and automation for next-generation capabilities.",
-        "applicableWhen": {
-          "averageLevel": 5
-        },
-        "actions": [
+        "items": [
           "Implement AI-driven development processes",
           "Adopt serverless and edge computing",
           "Establish self-healing systems",
           "Implement predictive analytics"
         ],
+        "nextSteps": [
+          {
+            "href": "/tech-leadership/wiki/cloud-native/future-ready/",
+            "title": "Future Ready",
+            "description": "Wiki article with detailed guidance"
+          },
+          {
+            "href": "/tech-leadership/blog/ai-driven-development/",
+            "title": "Ai Driven Development",
+            "description": "Blog post with practical insights"
+          }
+        ],
         "priority": "low"
       }
     ]
-  }
+  },
+  "tags": [
+    "cloud-native",
+    "maturity-assessment",
+    "organizational-transformation",
+    "devops"
+  ],
+  "createdAt": "2025-07-14T00:00:00.000Z",
+  "updatedAt": "2025-07-14T00:00:00.000Z"
 }

--- a/public/tech-leadership/assessments/engineering-practices.json
+++ b/public/tech-leadership/assessments/engineering-practices.json
@@ -6,14 +6,6 @@
   "version": "1.0",
   "category": "Engineering Excellence",
   "estimatedTime": 15,
-  "tags": [
-    "engineering-practices",
-    "maturity-assessment",
-    "team-health",
-    "continuous-improvement"
-  ],
-  "createdAt": "2025-01-13T00:00:00.000Z",
-  "updatedAt": "2025-01-13T00:00:00.000Z",
   "sections": [
     {
       "id": "normalization",
@@ -320,9 +312,21 @@
           "Create basic documentation practices"
         ],
         "nextSteps": [
-          "/tech-leadership/wiki/engineering-practices/normalization/",
-          "/tech-leadership/blog/engineering-practices-health-check/",
-          "/tech-leadership/wiki/engineering-practices/normalization/version-control/"
+          {
+            "href": "/tech-leadership/wiki/engineering-practices/normalization/",
+            "title": "Normalization Stage",
+            "description": "Foundation building blocks: version control, guidelines, and standardized systems"
+          },
+          {
+            "href": "/tech-leadership/blog/engineering-practices-health-check/",
+            "title": "Engineering Practices Health Check: A Maturity Assessment Model",
+            "description": "Inspired by Spotify's squad health check, we present a comprehensive model for assessing engineering practices maturity across your organization"
+          },
+          {
+            "href": "/tech-leadership/wiki/engineering-practices/normalization/version-control/",
+            "title": "Version Control Systems",
+            "description": "Implementing Git workflows, branching strategies, and access control for effective code management"
+          }
         ],
         "priority": "high"
       },
@@ -340,9 +344,21 @@
           "Create template-based development workflows"
         ],
         "nextSteps": [
-          "/tech-leadership/wiki/engineering-practices/standardization/",
-          "/tech-leadership/wiki/engineering-practices/standardization/golden-path/",
-          "/tech-leadership/wiki/engineering-practices/standardization/infrastructure-as-code/"
+          {
+            "href": "/tech-leadership/wiki/engineering-practices/standardization/",
+            "title": "Standardization Stage",
+            "description": "Creating consistency through deployment patterns, Golden Path, and Infrastructure as Code"
+          },
+          {
+            "href": "/tech-leadership/wiki/engineering-practices/standardization/golden-path/",
+            "title": "Golden Path Implementation",
+            "description": "Creating and promoting paved road practices for common development workflows"
+          },
+          {
+            "href": "/tech-leadership/wiki/engineering-practices/standardization/infrastructure-as-code/",
+            "title": "Infrastructure as Code",
+            "description": "Declarative infrastructure management using Terraform, Kubernetes, and automated provisioning"
+          }
         ],
         "priority": "high"
       },
@@ -360,9 +376,21 @@
           "Enable teams with full stack capabilities"
         ],
         "nextSteps": [
-          "/tech-leadership/wiki/engineering-practices/expansion/",
-          "/tech-leadership/wiki/engineering-practices/expansion/autonomous-teams/",
-          "/tech-leadership/blog/autonomous-teams-implementation/"
+          {
+            "href": "/tech-leadership/wiki/engineering-practices/expansion/",
+            "title": "Expansion Stage",
+            "description": "Scaling autonomous teams through continuous integration and delivery practices"
+          },
+          {
+            "href": "/tech-leadership/wiki/engineering-practices/expansion/autonomous-teams/",
+            "title": "Autonomous Teams",
+            "description": "Empowering self-organized teams with end-to-end ownership, decision-making authority, and cross-functional capabilities"
+          },
+          {
+            "href": "/tech-leadership/blog/autonomous-teams-implementation/",
+            "title": "From Dependency Hell to Autonomous Teams: A Practical Implementation Guide",
+            "description": "Step-by-step guide to transforming dependent teams into autonomous, end-to-end ownership structures that deliver faster with higher quality"
+          }
         ],
         "priority": "medium"
       },
@@ -380,9 +408,21 @@
           "Create predictive analytics for system health"
         ],
         "nextSteps": [
-          "/tech-leadership/wiki/engineering-practices/automation/",
-          "/tech-leadership/wiki/engineering-practices/automation/automated-system-configuration/",
-          "/tech-leadership/wiki/engineering-practices/automation/devsecops/"
+          {
+            "href": "/tech-leadership/wiki/engineering-practices/automation/",
+            "title": "Automation Stage",
+            "description": "Full automation of system configuration, resource provisioning, and security integration"
+          },
+          {
+            "href": "/tech-leadership/wiki/engineering-practices/automation/automated-system-configuration/",
+            "title": "Automated System Configuration",
+            "description": "Configuration management, drift detection, and self-healing systems that ensure consistent and reliable infrastructure"
+          },
+          {
+            "href": "/tech-leadership/wiki/engineering-practices/automation/devsecops/",
+            "title": "DevSecOps Integration",
+            "description": "Integrating security practices throughout the software development lifecycle"
+          }
         ],
         "priority": "medium"
       },
@@ -400,12 +440,32 @@
           "Empower citizen developers with proper governance"
         ],
         "nextSteps": [
-          "/tech-leadership/wiki/engineering-practices/self-service/",
-          "/tech-leadership/wiki/engineering-practices/self-service/self-service-platform/",
-          "/tech-leadership/blog/golden-path-evolution/"
+          {
+            "href": "/tech-leadership/wiki/engineering-practices/self-service/",
+            "title": "Self-Service Stage",
+            "description": "Developer platforms, refined Golden Path, and citizen developer enablement"
+          },
+          {
+            "href": "/tech-leadership/wiki/engineering-practices/self-service/self-service-platform/",
+            "title": "Self-Service Platform",
+            "description": "Developer portals, infrastructure APIs, and automated workflows that enable team independence and rapid innovation"
+          },
+          {
+            "href": "/tech-leadership/blog/golden-path-evolution/",
+            "title": "The Evolution of Golden Paths: From Standardization to Intelligence",
+            "description": "How Golden Paths evolve from simple templates to intelligent, self-optimizing developer experiences that adapt to team needs"
+          }
         ],
         "priority": "low"
       }
     ]
-  }
+  },
+  "tags": [
+    "engineering-practices",
+    "maturity-assessment",
+    "team-health",
+    "continuous-improvement"
+  ],
+  "createdAt": "2025-01-13T00:00:00.000Z",
+  "updatedAt": "2025-01-13T00:00:00.000Z"
 }

--- a/scripts/generate-assessments.mjs
+++ b/scripts/generate-assessments.mjs
@@ -2,6 +2,85 @@ import { mkdir, writeFile, readFile } from 'fs/promises';
 import { join } from 'path';
 import ts from 'typescript';
 
+function parseFrontmatter(content) {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return {};
+  const data = {};
+  for (const line of match[1].split('\n')) {
+    if (!line || line.startsWith(' ')) continue;
+    const [key, ...rest] = line.split(':');
+    if (!key) continue;
+    data[key.trim()] = rest.join(':').trim().replace(/^"|"$/g, '');
+  }
+  return data;
+}
+
+function humanize(href) {
+  const parts = href.split('/').filter(p => p && !['tech-leadership', 'blog', 'wiki'].includes(p));
+  const slug = parts[parts.length - 1] || '';
+  return slug
+    .split('-')
+    .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+function defaultDesc(href) {
+  if (href.includes('/wiki/')) return 'Wiki article with detailed guidance';
+  if (href.includes('/blog/')) return 'Blog post with practical insights';
+  if (href.includes('/tools/')) return 'Interactive tool or calculator';
+  return 'Knowledge base resource';
+}
+
+async function resolveContentMeta(href) {
+  let path = href.replace(/^\/tech-leadership\//, '');
+  if (path.endsWith('/')) path = path.slice(0, -1);
+
+  if (path.startsWith('wiki/')) {
+    const rel = path.replace(/^wiki\//, '');
+    const base = join('src', 'content', 'wiki', rel);
+    let fileContent;
+    try {
+      fileContent = await readFile(base + '.md', 'utf8');
+    } catch {
+      try {
+        fileContent = await readFile(join(base, 'index.md'), 'utf8');
+      } catch {
+        return {};
+      }
+    }
+    return parseFrontmatter(fileContent);
+  } else if (path.startsWith('blog/')) {
+    const rel = path.replace(/^blog\//, '') + '.md';
+    try {
+      const fileContent = await readFile(join('src', 'content', 'blog', rel), 'utf8');
+      return parseFrontmatter(fileContent);
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+async function enrichNextSteps(assessments) {
+  for (const assessment of assessments) {
+    const recs = assessment.scoring?.recommendations || [];
+    for (const rec of recs) {
+      if (!rec.nextSteps) continue;
+      rec.nextSteps = await Promise.all(
+        rec.nextSteps.map(async step => {
+          const href = typeof step === 'string' ? step : step.href;
+          const meta = await resolveContentMeta(href);
+          return {
+            href,
+            title: meta.title || (typeof step === 'string' ? humanize(href) : step.title),
+            description: meta.description || (typeof step === 'string' ? defaultDesc(href) : step.description)
+          };
+        })
+      );
+    }
+  }
+}
+
 async function loadAssessments() {
   const source = await readFile('src/data/assessments.ts', 'utf8');
   const transpiled = ts.transpileModule(source, {
@@ -13,6 +92,7 @@ async function loadAssessments() {
 }
 
 const assessments = await loadAssessments();
+await enrichNextSteps(assessments);
 const outputDir = join(process.cwd(), 'public', 'tech-leadership', 'assessments');
 await mkdir(outputDir, { recursive: true });
 

--- a/src/data/assessment-types.ts
+++ b/src/data/assessment-types.ts
@@ -92,8 +92,14 @@ export interface AssessmentRecommendation {
   title: string;
   description: string;
   items: string[];
-  nextSteps: string[];
+  nextSteps: NextStep[];
   priority: 'high' | 'medium' | 'low';
+}
+
+export interface NextStep {
+  href: string;
+  title: string;
+  description: string;
 }
 
 // Response and result types

--- a/src/data/assessments.ts
+++ b/src/data/assessments.ts
@@ -24,8 +24,14 @@ export interface AssessmentRecommendation {
   title: string;
   description: string;
   items: string[];
-  nextSteps: string[];
+  nextSteps: NextStep[];
   priority: 'high' | 'medium' | 'low';
+}
+
+export interface NextStep {
+  href: string;
+  title: string;
+  description: string;
 }
 
 export interface Assessment {
@@ -305,9 +311,21 @@ export const engineeringPracticesAssessment: Assessment = {
           'Create basic documentation practices'
         ],
         nextSteps: [
-          '/tech-leadership/wiki/engineering-practices/normalization/',
-          '/tech-leadership/blog/engineering-practices-health-check/',
-          '/tech-leadership/wiki/engineering-practices/normalization/version-control/'
+          {
+            href: '/tech-leadership/wiki/engineering-practices/normalization/',
+            title: 'Normalization Stage',
+            description: 'Foundation building blocks: version control, guidelines, and standardized systems'
+          },
+          {
+            href: '/tech-leadership/blog/engineering-practices-health-check/',
+            title: 'Engineering Practices Health Check: A Maturity Assessment Model',
+            description: 'Inspired by Spotify\'s squad health check, we present a comprehensive model for assessing engineering practices maturity across your organization'
+          },
+          {
+            href: '/tech-leadership/wiki/engineering-practices/normalization/version-control/',
+            title: 'Version Control Systems',
+            description: 'Implementing Git workflows, branching strategies, and access control for effective code management'
+          }
         ],
         priority: 'high'
       },
@@ -322,9 +340,21 @@ export const engineeringPracticesAssessment: Assessment = {
           'Create template-based development workflows'
         ],
         nextSteps: [
-          '/tech-leadership/wiki/engineering-practices/standardization/',
-          '/tech-leadership/wiki/engineering-practices/standardization/golden-path/',
-          '/tech-leadership/wiki/engineering-practices/standardization/infrastructure-as-code/'
+          {
+            href: '/tech-leadership/wiki/engineering-practices/standardization/',
+            title: 'Standardization Stage',
+            description: 'Creating consistency through deployment patterns, Golden Path, and Infrastructure as Code'
+          },
+          {
+            href: '/tech-leadership/wiki/engineering-practices/standardization/golden-path/',
+            title: 'Golden Path Implementation',
+            description: 'Creating and promoting paved road practices for common development workflows'
+          },
+          {
+            href: '/tech-leadership/wiki/engineering-practices/standardization/infrastructure-as-code/',
+            title: 'Infrastructure as Code',
+            description: 'Declarative infrastructure management using Terraform, Kubernetes, and automated provisioning'
+          }
         ],
         priority: 'high'
       },
@@ -339,9 +369,21 @@ export const engineeringPracticesAssessment: Assessment = {
           'Enable teams with full stack capabilities'
         ],
         nextSteps: [
-          '/tech-leadership/wiki/engineering-practices/expansion/',
-          '/tech-leadership/wiki/engineering-practices/expansion/autonomous-teams/',
-          '/tech-leadership/blog/autonomous-teams-implementation/'
+          {
+            href: '/tech-leadership/wiki/engineering-practices/expansion/',
+            title: 'Expansion Stage',
+            description: 'Scaling autonomous teams through continuous integration and delivery practices'
+          },
+          {
+            href: '/tech-leadership/wiki/engineering-practices/expansion/autonomous-teams/',
+            title: 'Autonomous Teams',
+            description: 'Empowering self-organized teams with end-to-end ownership, decision-making authority, and cross-functional capabilities'
+          },
+          {
+            href: '/tech-leadership/blog/autonomous-teams-implementation/',
+            title: 'From Dependency Hell to Autonomous Teams: A Practical Implementation Guide',
+            description: 'Step-by-step guide to transforming dependent teams into autonomous, end-to-end ownership structures that deliver faster with higher quality'
+          }
         ],
         priority: 'medium'
       },
@@ -356,9 +398,21 @@ export const engineeringPracticesAssessment: Assessment = {
           'Create predictive analytics for system health'
         ],
         nextSteps: [
-          '/tech-leadership/wiki/engineering-practices/automation/',
-          '/tech-leadership/wiki/engineering-practices/automation/automated-system-configuration/',
-          '/tech-leadership/wiki/engineering-practices/automation/devsecops/'
+          {
+            href: '/tech-leadership/wiki/engineering-practices/automation/',
+            title: 'Automation Stage',
+            description: 'Full automation of system configuration, resource provisioning, and security integration'
+          },
+          {
+            href: '/tech-leadership/wiki/engineering-practices/automation/automated-system-configuration/',
+            title: 'Automated System Configuration',
+            description: 'Configuration management, drift detection, and self-healing systems that ensure consistent and reliable infrastructure'
+          },
+          {
+            href: '/tech-leadership/wiki/engineering-practices/automation/devsecops/',
+            title: 'DevSecOps Integration',
+            description: 'Integrating security practices throughout the software development lifecycle'
+          }
         ],
         priority: 'medium'
       },
@@ -373,9 +427,21 @@ export const engineeringPracticesAssessment: Assessment = {
           'Empower citizen developers with proper governance'
         ],
         nextSteps: [
-          '/tech-leadership/wiki/engineering-practices/self-service/',
-          '/tech-leadership/wiki/engineering-practices/self-service/self-service-platform/',
-          '/tech-leadership/blog/golden-path-evolution/'
+          {
+            href: '/tech-leadership/wiki/engineering-practices/self-service/',
+            title: 'Self-Service Stage',
+            description: 'Developer platforms, refined Golden Path, and citizen developer enablement'
+          },
+          {
+            href: '/tech-leadership/wiki/engineering-practices/self-service/self-service-platform/',
+            title: 'Self-Service Platform',
+            description: 'Developer portals, infrastructure APIs, and automated workflows that enable team independence and rapid innovation'
+          },
+          {
+            href: '/tech-leadership/blog/golden-path-evolution/',
+            title: 'The Evolution of Golden Paths: From Standardization to Intelligence',
+            description: 'How Golden Paths evolve from simple templates to intelligent, self-optimizing developer experiences that adapt to team needs'
+          }
         ],
         priority: 'low'
       }
@@ -542,8 +608,16 @@ export const cloudNativeMaturityAssessment: MatrixAssessment = {
           'Adopt agile development practices'
         ],
         nextSteps: [
-          '/tech-leadership/wiki/cloud-native/foundation/',
-          '/tech-leadership/blog/cloud-native-getting-started/'
+          {
+            href: '/tech-leadership/wiki/cloud-native/foundation/',
+            title: 'Cloud Native Foundation',
+            description: 'Wiki article with detailed guidance'
+          },
+          {
+            href: '/tech-leadership/blog/cloud-native-getting-started/',
+            title: 'Cloud Native Getting Started',
+            description: 'Blog post with practical insights'
+          }
         ],
         priority: 'high'
       },
@@ -558,8 +632,16 @@ export const cloudNativeMaturityAssessment: MatrixAssessment = {
           'Begin containerization journey'
         ],
         nextSteps: [
-          '/tech-leadership/wiki/cloud-native/agile-transformation/',
-          '/tech-leadership/tools/'
+          {
+            href: '/tech-leadership/wiki/cloud-native/agile-transformation/',
+            title: 'Agile Transformation',
+            description: 'Wiki article with detailed guidance'
+          },
+          {
+            href: '/tech-leadership/tools/',
+            title: 'Tools',
+            description: 'Interactive tool or calculator'
+          }
         ],
         priority: 'high'
       },
@@ -574,8 +656,16 @@ export const cloudNativeMaturityAssessment: MatrixAssessment = {
           'Establish chaos engineering practices'
         ],
         nextSteps: [
-          '/tech-leadership/wiki/cloud-native/microservices/',
-          '/tech-leadership/wiki/cloud-native/observability/'
+          {
+            href: '/tech-leadership/wiki/cloud-native/microservices/',
+            title: 'Microservices',
+            description: 'Wiki article with detailed guidance'
+          },
+          {
+            href: '/tech-leadership/wiki/cloud-native/observability/',
+            title: 'Observability',
+            description: 'Wiki article with detailed guidance'
+          }
         ],
         priority: 'medium'
       },
@@ -590,8 +680,16 @@ export const cloudNativeMaturityAssessment: MatrixAssessment = {
           'Implement predictive analytics'
         ],
         nextSteps: [
-          '/tech-leadership/wiki/cloud-native/future-ready/',
-          '/tech-leadership/blog/ai-driven-development/'
+          {
+            href: '/tech-leadership/wiki/cloud-native/future-ready/',
+            title: 'Future Ready',
+            description: 'Wiki article with detailed guidance'
+          },
+          {
+            href: '/tech-leadership/blog/ai-driven-development/',
+            title: 'Ai Driven Development',
+            description: 'Blog post with practical insights'
+          }
         ],
         priority: 'low'
       }

--- a/src/pages/assessments/[id].astro
+++ b/src/pages/assessments/[id].astro
@@ -362,7 +362,7 @@ const assessmentTitle = id === 'engineering-practices'
               
               <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
                 <template x-for="(link, index) in getRecommendationsByScore().nextSteps || []" :key="index">
-                  <a :href="link" class="group bg-primary-50 dark:bg-primary-700 hover:bg-accent-50 dark:hover:bg-accent-900/20 rounded-lg p-4 transition-all duration-200 block">
+                  <a :href="link.href" class="group bg-primary-50 dark:bg-primary-700 hover:bg-accent-50 dark:hover:bg-accent-900/20 rounded-lg p-4 transition-all duration-200 block">
                     <div class="flex items-start">
                       <div class="flex-shrink-0 w-8 h-8 bg-accent-600 text-white rounded-lg flex items-center justify-center mr-3">
                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -370,8 +370,8 @@ const assessmentTitle = id === 'engineering-practices'
                         </svg>
                       </div>
                       <div class="flex-1 min-w-0">
-                        <h4 class="text-sm font-semibold text-primary-900 dark:text-primary-100 group-hover:text-accent-600 transition-colors" x-text="getLinkTitle(link)"></h4>
-                        <p class="text-xs text-primary-500 dark:text-primary-400 mt-1" x-text="getLinkDescription(link)"></p>
+                        <h4 class="text-sm font-semibold text-primary-900 dark:text-primary-100 group-hover:text-accent-600 transition-colors" x-text="link.title"></h4>
+                        <p class="text-xs text-primary-500 dark:text-primary-400 mt-1" x-text="link.description"></p>
                       </div>
                       <div class="flex-shrink-0 ml-2">
                         <svg class="w-4 h-4 text-primary-400 group-hover:text-accent-600 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/utils/questionnaire.ts
+++ b/src/utils/questionnaire.ts
@@ -246,28 +246,6 @@ export function directQuestionnaireAssessment() {
       return actionItems.slice(0, 6); // Limit to 6 items
     },
 
-    getLinkTitle(link: string) {
-      const pathParts = link.split('/').filter(part => part && part !== 'tech-leadership');
-      if (pathParts.length >= 2) {
-        const lastPart = pathParts[pathParts.length - 1] || pathParts[pathParts.length - 2];
-        return lastPart
-          .split('-')
-          .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-          .join(' ');
-      }
-      return 'Knowledge Base Article';
-    },
-
-    getLinkDescription(link: string) {
-      if (link.includes('/wiki/')) {
-        return 'Wiki article with detailed guidance';
-      } else if (link.includes('/blog/')) {
-        return 'Blog post with practical insights';
-      } else if (link.includes('/tools/')) {
-        return 'Interactive tool or calculator';
-      }
-      return 'Knowledge base resource';
-    },
 
     restartAssessment() {
       this.showResults = false;


### PR DESCRIPTION
## Summary
- structure next step recommendations with href/title/description metadata
- render recommendation cards directly from these fields and drop runtime link helpers
- add build-time script to resolve next step metadata from linked content

## Testing
- `npm test`
- `npm run generate:assessments`


------
https://chatgpt.com/codex/tasks/task_b_689c88093368832484a0ebe1b2d283ca