### PR TITLE
Fix operating model card link

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -224,7 +224,7 @@ const tags = [
           <p class="text-primary-700 dark:text-primary-300 mb-4">
             Comprehensive approach to organizational design, culture development, decision-making, and continuous optimization for technology teams.
           </p>
-          <a href="/tech-leadership/wiki/operating-model/" class="inline-flex items-center text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 font-medium group-hover:translate-x-1 transition-transform">
+          <a href="/tech-leadership/wiki/operating-model/operating-model-framework/" class="inline-flex items-center text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 font-medium group-hover:translate-x-1 transition-transform">
             Explore Framework
             <svg class="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>


### PR DESCRIPTION
## Summary
- fix the Operating Model card on the home page so it links to the published framework entry instead of a missing route

## Testing
- npm run test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691c412e7a008324b2f915800a2c456f)